### PR TITLE
Switch to BrowserRouter and fix news navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
 
     <!-- Base for router paths -->
-    <base href="/" />
+    <base href="/tektonikaaa/" />
 
     <!-- Global Styles -->
     <link rel="stylesheet" href="/src/index.css" />

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://richmanstudio.github.io/tektonikaaa#",
+  "homepage": "https://richmanstudio.github.io/tektonikaaa",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,14 @@
 // src/main.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import AppRoutes from "./routes/index";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <HashRouter>
+    <BrowserRouter basename="/tektonikaaa/">
       <AppRoutes />
-    </HashRouter>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from "react";
 import Layout from "../layouts/MainLayout";
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 import heroImg from "../assets/abouthero-bg.jpg";
 import logo from "../assets/logo.png";
 import { GraduationCap, MapPin, Phone, Clock, Heart, BookOpen, Gift } from "lucide-react";
@@ -32,7 +33,11 @@ export default function About() {
       {/* Breadcrumbs */}
       <nav className="bg-gray-50 px-6 py-3 rounded-md text-sm mb-8">
         <ol className="list-reset flex text-gray-600">
-          <li><a href="/" className="hover:text-blue-600">Главная</a></li>
+          <li>
+            <Link to="/" className="hover:text-blue-600">
+              Главная
+            </Link>
+          </li>
           <li><span className="mx-2">/</span></li>
           <li className="text-gray-800 font-semibold">О нас</li>
         </ol>

--- a/src/pages/Media.tsx
+++ b/src/pages/Media.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import Layout from '../layouts/MainLayout';
 import { Newspaper, Image, FileText } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
 
 interface NewsItem {
   id: string;
@@ -123,12 +124,12 @@ export default function Media() {
                     </h3>
                     <p className="text-gray-500 text-sm mb-4">{item.date}</p>
                     <p className="text-gray-700 mb-4">{item.summary}</p>
-                    <a
-                      href={item.link}
+                    <Link
+                      to={item.link}
                       className="text-blue-700 font-medium hover:underline"
                     >
                       Читать далее →
-                    </a>
+                    </Link>
                   </article>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- switch routing to `BrowserRouter`
- update base href for correct asset paths
- adjust GH pages homepage
- fix breadcrumb and news links to use React Router

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685637b7bf108331bfe1b021b8a01a61